### PR TITLE
Wildcard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ provider "aws" {
 module "website" {
   source = "modules/terraform-module-s3-cloudfront"
 
-  name     = "my-first-website"
-  hostname = "example.com"
+  name         = "my-first-website"
+  hostname     = "example.com"
+  wildcard_ssl = "*.example.com"
+  
   aliases  = [
   	"example.net",
   	"example.org"
@@ -59,6 +61,7 @@ directory of this repository.
 ## Authors
 
 Jonathan Wright <jon@than.io>
+Dave Dash <dd@davedash.com>
 
 ## License
 

--- a/certificate.tf
+++ b/certificate.tf
@@ -10,5 +10,5 @@ provider "aws" {
 
 data "aws_acm_certificate" "frontend" {
   provider = "aws.us-east-1"
-  domain   = "${var.hostname}"
+  domain   = "${coalesce(var.wildcard_ssl, var.hostname)}"
 }

--- a/examples/wildcard/README.md
+++ b/examples/wildcard/README.md
@@ -1,0 +1,28 @@
+# Example Usage
+
+The example in this directory will utilize a Wildcard SSL certificate.
+
+## Important
+
+This module will create an encrypted (i.e. HTTPS) endpoint in CloudFront using
+[Amazon Certificate Manager](https://aws.amazon.com/certificate-manager/). ACM
+cannot be automated at this time as it requires manual steps in the approval
+of the domain name before it can be added into the account. Please therefore
+setup the certificate for the domain name you require (and any aliases you may
+include as well) by following the
+[Getting Started](http://docs.aws.amazon.com/acm/latest/userguide/gs.html) guide
+in the AWS Documentation.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which can cost money (logs stored
+within S3, for example). Run `terraform destroy` when you don't need these
+resources.

--- a/examples/wildcard/main.tf
+++ b/examples/wildcard/main.tf
@@ -1,0 +1,16 @@
+provider "aws" {
+  region = "eu-west-2"
+}
+
+module "website" {
+  source = "../../"
+
+  name         = "my-first-website"
+  hostname     = "mysite.example.com"
+  wildcard_ssl = "*.example.com"
+
+  tags {
+    Domain = "mysite.example.com"
+    Owner  = "webmaster@example.com"
+  }
+}

--- a/examples/wildcard/outputs.tf
+++ b/examples/wildcard/outputs.tf
@@ -1,0 +1,15 @@
+output "hostname" {
+  value = "${module.website.hostname}"
+}
+
+output "s3_bucket_name" {
+  value = "${module.website.s3_bucket_name}"
+}
+
+output "cloudfront_distribution_id" {
+  value = "${module.website.cloudfront_distribution_id}"
+}
+
+output "cloudfront_distribution_hostname" {
+  value = "${module.website.cloudfront_distribution_hostname}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,8 @@ output "cloudfront_distribution_hostname" {
   description = "The hostname of the CloudFront Distribution (use for DNS CNAME)."
   value       = "${aws_cloudfront_distribution.website.domain_name}"
 }
+
+output "cloudfront_zone_id" {
+  description = "The Zone ID of the CloudFront Distribution (use for DNS Alias)."
+  value       = "${aws_cloudfront_distribution.website.hosted_zone_id}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "hostname" {
   default     = "example.com"
 }
 
+variable "wildcard_ssl" {
+  description = "Wildcard SSL certificate domain name.  E.g. *.example.com"
+  default     = ""
+}
+
 variable "aliases" {
   description = "Additional aliases to host this website for."
   default     = []


### PR DESCRIPTION
Hi @jonathanio ,

I use a wildcard SSL cert in one of my projects and therefore it had a name that doesn't match the hostname, so I made this PR to handle that case with an optional `wildcard_ssl` parameter (I'm not married to that name, but it seems to fit).  

Additionally I exposed a CloudFront output that is needed if you use Route53's Aliasing.

Cheers,

-d