### PR TITLE
Remove bucket policies dependent on current user.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,2 +1,1 @@
-/* Pull out useful data resources for later processing */
-data "aws_caller_identity" "current" {}
+

--- a/s3-content.tf
+++ b/s3-content.tf
@@ -67,26 +67,4 @@ data "aws_iam_policy_document" "s3_bucket_content" {
       identifiers = ["${aws_cloudfront_origin_access_identity.website.iam_arn}"]
     }
   }
-
-  statement {
-    sid    = "AllowCurrentUserFullAccess"
-    effect = "Allow"
-
-    principals = {
-      type = "AWS"
-
-      identifiers = [
-        "${data.aws_caller_identity.current.arn}",
-      ]
-    }
-
-    actions = [
-      "s3:*",
-    ]
-
-    resources = [
-      "${aws_s3_bucket.content.arn}",
-      "${aws_s3_bucket.content.arn}/*",
-    ]
-  }
 }

--- a/s3-logs.tf
+++ b/s3-logs.tf
@@ -23,32 +23,3 @@ resource "aws_s3_bucket" "logs" {
 
   tags = "${merge(var.tags, map("Name", format("s3-cloudfront-%s-logs", var.name)))}"
 }
-
-resource "aws_s3_bucket_policy" "logs" {
-  bucket = "${aws_s3_bucket.logs.id}"
-  policy = "${data.aws_iam_policy_document.s3_bucket_logging.json}"
-}
-
-data "aws_iam_policy_document" "s3_bucket_logging" {
-  statement {
-    sid    = "AllowCurrentUserFullAccess"
-    effect = "Allow"
-
-    principals {
-      type = "AWS"
-
-      identifiers = [
-        "${data.aws_caller_identity.current.arn}",
-      ]
-    }
-
-    actions = [
-      "s3:*",
-    ]
-
-    resources = [
-      "${aws_s3_bucket.logs.arn}",
-      "${aws_s3_bucket.logs.arn}/*",
-    ]
-  }
-}


### PR DESCRIPTION
I removed these bucket policies that are based on the current user that's executing terraform.  This may not be the direction you'd like to go, and might make more work for you, but this causes a problem if you use vault to distribute AWS credentials.  In my case my AWS credentials are terraform specific and are IAM users that exist for a short duration.

If this is a use case that needs to be preserved, I'd expose the bucket.arn and handle it outside of the module itself.

Let me know your thoughts.