### PR TITLE
Improve Permissions Control

### DIFF
--- a/examples/policies/README.md
+++ b/examples/policies/README.md
@@ -1,0 +1,29 @@
+# Example Usage
+
+The example in this directory is the recommended minimum needed to setup this
+module (i.e. `name` and `hostname`).
+
+## Important
+
+This module will create an encrypted (i.e. HTTPS) endpoint in CloudFront using
+[Amazon Certificate Manager](https://aws.amazon.com/certificate-manager/). ACM
+cannot be automated at this time as it requires manual steps in the approval
+of the domain name before it can be added into the account. Please therefore
+setup the certificate for the domain name you require (and any aliases you may
+include as well) by following the
+[Getting Started](http://docs.aws.amazon.com/acm/latest/userguide/gs.html) guide
+in the AWS Documentation.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which can cost money (logs stored
+within S3, for example). Run `terraform destroy` when you don't need these
+resources.

--- a/examples/policies/aws.tf
+++ b/examples/policies/aws.tf
@@ -1,0 +1,2 @@
+/* Pull out useful data resources for later processing */
+data "aws_caller_identity" "current" {}

--- a/examples/policies/groups.tf
+++ b/examples/policies/groups.tf
@@ -1,0 +1,10 @@
+resource "aws_iam_group" "content_upload" {
+  name = "WebsiteDevelopers"
+}
+
+resource "aws_iam_group_policy" "content_upload" {
+  name  = "WebsiteDeveloperAccess"
+  group = "${aws_iam_group.content_upload.id}"
+
+  policy = "${data.aws_iam_policy_document.content_upload.json}"
+}

--- a/examples/policies/main.tf
+++ b/examples/policies/main.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region = "eu-west-2"
+}
+
+module "website" {
+  source = "../../"
+
+  name     = "my-first-website"
+  hostname = "example.com"
+
+  tags {
+    Domain = "example.com"
+    Owner  = "webmaster@example.com"
+  }
+}

--- a/examples/policies/outputs.tf
+++ b/examples/policies/outputs.tf
@@ -1,0 +1,15 @@
+output "hostname" {
+  value = "${module.website.hostname}"
+}
+
+output "s3_bucket_name" {
+  value = "${module.website.s3_bucket_name}"
+}
+
+output "cloudfront_distribution_id" {
+  value = "${module.website.cloudfront_distribution_id}"
+}
+
+output "cloudfront_distribution_hostname" {
+  value = "${module.website.cloudfront_distribution_hostname}"
+}

--- a/examples/policies/policies.tf
+++ b/examples/policies/policies.tf
@@ -1,0 +1,50 @@
+data "aws_iam_policy_document" "content_upload" {
+  statement {
+    sid    = "AllowS3WebsiteWriteAccessCurrentUser"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}",
+      ]
+    }
+
+    actions = [
+      "s3:DeleteObject",
+      "s3:DeleteObjectTagging",
+      "s3:Get*",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:PutObjectTagging",
+      "s3:RestoreObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${module.website.s3_bucket_name}/*",
+    ]
+  }
+
+  statement {
+    sid    = "AllowS3WebsiteBucketAccessCurrentUser"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/$${aws:username}",
+      ]
+    }
+
+    actions = [
+      "s3:ListBucket",
+      "s3:ListBucketVersions",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${module.website.s3_bucket_name}",
+    ]
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "hostname" {
 }
 
 output "s3_bucket_name" {
-  description = "The name of the S3 bucket to upload the website content to."
+  description = "The name of the S3 content bucket to upload the website content to."
   value       = "${aws_s3_bucket.content.id}"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "s3_bucket_name" {
   value       = "${aws_s3_bucket.content.id}"
 }
 
+output "s3_logging_name" {
+  description = "The name of the S3 logging bucket that access logs will be saved to."
+  value       = "${aws_s3_bucket.logs.id}"
+}
+
 output "cloudfront_distribution_id" {
   description = "The ID of the CloudFront Distribution."
   value       = "${aws_cloudfront_distribution.website.id}"


### PR DESCRIPTION
Update the module to improve permissions control on the buckets. Following @davedash's update to remove some control from within the module, a new example has been written which shows how to create a group and policy to provide granular write access to the content bucket for the website developers.