### PR TITLE
Update for Terraform 0.12 support

### DIFF
--- a/certificate.tf
+++ b/certificate.tf
@@ -9,6 +9,6 @@ provider "aws" {
 }
 
 data "aws_acm_certificate" "frontend" {
-  provider = "aws.us-east-1"
-  domain   = "${coalesce(var.wildcard_ssl, var.hostname)}"
+  provider = aws.us-east-1
+  domain   = coalesce(var.wildcard_ssl, var.hostname)
 }

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -3,20 +3,20 @@ resource "aws_cloudfront_distribution" "website" {
   is_ipv6_enabled = true
   http_version    = "http2"
 
-  aliases = ["${compact(concat(list(var.hostname),var.aliases))}"]
+  aliases = compact(concat(list(var.hostname),var.aliases))
 
   viewer_certificate {
-    acm_certificate_arn      = "${data.aws_acm_certificate.frontend.arn}"
+    acm_certificate_arn      = data.aws_acm_certificate.frontend.arn
     minimum_protocol_version = "TLSv1"
     ssl_support_method       = "sni-only"
   }
 
   origin {
-    domain_name = "${aws_s3_bucket.content.bucket_domain_name}"
-    origin_id   = "${aws_s3_bucket.content.id}"
+    domain_name = aws_s3_bucket.content.bucket_domain_name
+    origin_id   = aws_s3_bucket.content.id
 
     s3_origin_config {
-      origin_access_identity = "${aws_cloudfront_origin_access_identity.website.cloudfront_access_identity_path}"
+      origin_access_identity = aws_cloudfront_origin_access_identity.website.cloudfront_access_identity_path
     }
   }
 
@@ -25,14 +25,14 @@ resource "aws_cloudfront_distribution" "website" {
   default_cache_behavior {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = "${aws_s3_bucket.content.id}"
+    target_origin_id = aws_s3_bucket.content.id
 
     compress               = true
     viewer_protocol_policy = "redirect-to-https"
 
-    default_ttl = "${var.cache_ttl}"
-    min_ttl     = "${(var.cache_ttl / 4) < 60 ? 0 : floor(var.cache_ttl / 4)}"
-    max_ttl     = "${floor(var.cache_ttl * 24)}"
+    default_ttl = var.cache_ttl
+    min_ttl     = (var.cache_ttl / 4) < 60 ? 0 : floor(var.cache_ttl / 4)
+    max_ttl     = floor(var.cache_ttl * 24)
 
     forwarded_values {
       query_string = false
@@ -48,7 +48,7 @@ resource "aws_cloudfront_distribution" "website" {
   // 100: Limit to only Europe, USA, and Canada endpoints.
   // 200: + Hong Kong, Philippines, South Korea, Singapore, & Taiwan.
   // All: + South America, and Australa.
-  price_class = "${var.price_class}"
+  price_class = var.price_class
 
   restrictions {
     geo_restriction {
@@ -58,11 +58,11 @@ resource "aws_cloudfront_distribution" "website" {
 
   logging_config {
     include_cookies = false
-    bucket          = "${aws_s3_bucket.logs.bucket_domain_name}"
+    bucket          = aws_s3_bucket.logs.bucket_domain_name
     prefix          = "${var.hostname}/cloudfront"
   }
 
-  tags = "${merge(var.tags, map("Name", format("s3-cloudfront-%s-distribution", var.name)))}"
+  tags = merge(var.tags, map("Name", format("s3-cloudfront-%s-distribution", var.name)))
 }
 
 resource "aws_cloudfront_origin_access_identity" "website" {

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -3,7 +3,7 @@ resource "aws_cloudfront_distribution" "website" {
   is_ipv6_enabled = true
   http_version    = "http2"
 
-  aliases = compact(concat(list(var.hostname),var.aliases))
+  aliases = compact(concat(tolist([var.hostname]), var.aliases))
 
   viewer_certificate {
     acm_certificate_arn      = data.aws_acm_certificate.frontend.arn
@@ -62,7 +62,7 @@ resource "aws_cloudfront_distribution" "website" {
     prefix          = "${var.hostname}/cloudfront"
   }
 
-  tags = merge(var.tags, map("Name", format("s3-cloudfront-%s-distribution", var.name)))
+  tags = merge(var.tags, tomap({ "Name" = format("s3-cloudfront-%s-distribution", var.name) }))
 }
 
 resource "aws_cloudfront_origin_access_identity" "website" {

--- a/examples/policies/groups.tf
+++ b/examples/policies/groups.tf
@@ -4,7 +4,7 @@ resource "aws_iam_group" "content_upload" {
 
 resource "aws_iam_group_policy" "content_upload" {
   name  = "WebsiteDeveloperAccess"
-  group = "${aws_iam_group.content_upload.id}"
+  group = aws_iam_group.content_upload.id
 
-  policy = "${data.aws_iam_policy_document.content_upload.json}"
+  policy = data.aws_iam_policy_document.content_upload.json
 }

--- a/examples/policies/outputs.tf
+++ b/examples/policies/outputs.tf
@@ -1,15 +1,15 @@
 output "hostname" {
-  value = "${module.website.hostname}"
+  value = module.website.hostname
 }
 
 output "s3_bucket_name" {
-  value = "${module.website.s3_bucket_name}"
+  value = module.website.s3_bucket_name
 }
 
 output "cloudfront_distribution_id" {
-  value = "${module.website.cloudfront_distribution_id}"
+  value = module.website.cloudfront_distribution_id
 }
 
 output "cloudfront_distribution_hostname" {
-  value = "${module.website.cloudfront_distribution_hostname}"
+  value = module.website.cloudfront_distribution_hostname
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,25 +5,25 @@ output "hostname" {
 
 output "s3_bucket_name" {
   description = "The name of the S3 content bucket to upload the website content to."
-  value       = "${aws_s3_bucket.content.id}"
+  value       = aws_s3_bucket.content.id
 }
 
 output "s3_logging_name" {
   description = "The name of the S3 logging bucket that access logs will be saved to."
-  value       = "${aws_s3_bucket.logs.id}"
+  value       = aws_s3_bucket.logs.id
 }
 
 output "cloudfront_distribution_id" {
   description = "The ID of the CloudFront Distribution."
-  value       = "${aws_cloudfront_distribution.website.id}"
+  value       = aws_cloudfront_distribution.website.id
 }
 
 output "cloudfront_distribution_hostname" {
   description = "The hostname of the CloudFront Distribution (use for DNS CNAME)."
-  value       = "${aws_cloudfront_distribution.website.domain_name}"
+  value       = aws_cloudfront_distribution.website.domain_name
 }
 
 output "cloudfront_zone_id" {
   description = "The Zone ID of the CloudFront Distribution (use for DNS Alias)."
-  value       = "${aws_cloudfront_distribution.website.hosted_zone_id}"
+  value       = aws_cloudfront_distribution.website.hosted_zone_id
 }

--- a/s3-content.tf
+++ b/s3-content.tf
@@ -34,7 +34,7 @@ resource "aws_s3_bucket" "content" {
     target_prefix = "${var.hostname}/s3"
   }
 
-  tags = merge(var.tags, map("Name", format("s3-cloudfront-%s-content", var.name)))
+  tags = merge(var.tags, tomap({ "Name" = format("s3-cloudfront-%s-content", var.name) }))
 }
 
 resource "aws_s3_bucket_policy" "content" {

--- a/s3-content.tf
+++ b/s3-content.tf
@@ -1,15 +1,15 @@
 resource "aws_s3_bucket" "content" {
   bucket        = "s3-cloudfront-${lower(var.name)}-content"
   acl           = "public-read"
-  force_destroy = "${var.force_destroy}"
+  force_destroy = var.force_destroy
 
   versioning {
     enabled = true
   }
 
   website {
-    index_document = "${var.index_document}"
-    error_document = "${var.error_document}"
+    index_document = var.index_document
+    error_document = var.error_document
   }
 
   cors_rule {
@@ -17,7 +17,7 @@ resource "aws_s3_bucket" "content" {
     allowed_methods = ["GET", "HEAD"]
     allowed_origins = ["https://${var.hostname}"]
     expose_headers  = ["ETag"]
-    max_age_seconds = "${var.cache_ttl}"
+    max_age_seconds = var.cache_ttl
   }
 
   lifecycle_rule {
@@ -30,16 +30,16 @@ resource "aws_s3_bucket" "content" {
   }
 
   logging {
-    target_bucket = "${aws_s3_bucket.logs.id}"
+    target_bucket = aws_s3_bucket.logs.id
     target_prefix = "${var.hostname}/s3"
   }
 
-  tags = "${merge(var.tags, map("Name", format("s3-cloudfront-%s-content", var.name)))}"
+  tags = merge(var.tags, map("Name", format("s3-cloudfront-%s-content", var.name)))
 }
 
 resource "aws_s3_bucket_policy" "content" {
-  bucket = "${aws_s3_bucket.content.id}"
-  policy = "${data.aws_iam_policy_document.s3_bucket_content.json}"
+  bucket = aws_s3_bucket.content.id
+  policy = data.aws_iam_policy_document.s3_bucket_content.json
 }
 
 data "aws_iam_policy_document" "s3_bucket_content" {
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "s3_bucket_content" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${aws_cloudfront_origin_access_identity.website.iam_arn}"]
+      identifiers = [aws_cloudfront_origin_access_identity.website.iam_arn]
     }
   }
 
@@ -61,11 +61,11 @@ data "aws_iam_policy_document" "s3_bucket_content" {
     effect = "Allow"
 
     actions   = ["s3:ListBucket"]
-    resources = ["${aws_s3_bucket.content.arn}"]
+    resources = [aws_s3_bucket.content.arn]
 
     principals {
       type        = "AWS"
-      identifiers = ["${aws_cloudfront_origin_access_identity.website.iam_arn}"]
+      identifiers = [aws_cloudfront_origin_access_identity.website.iam_arn]
     }
   }
 }

--- a/s3-logs.tf
+++ b/s3-logs.tf
@@ -22,5 +22,5 @@ resource "aws_s3_bucket" "logs" {
     }
   }
 
-  tags = merge(var.tags, map("Name", format("s3-cloudfront-%s-logs", var.name)))
+  tags = merge(var.tags, tomap({ "Name" = format("s3-cloudfront-%s-logs", var.name) }))
 }

--- a/s3-logs.tf
+++ b/s3-logs.tf
@@ -1,26 +1,26 @@
 resource "aws_s3_bucket" "logs" {
   bucket        = "s3-cloudfront-${lower(var.name)}-logs"
   acl           = "log-delivery-write"
-  force_destroy = "${var.force_destroy}"
+  force_destroy = var.force_destroy
 
   lifecycle_rule {
     id      = "s3-cloudfront-${lower(var.name)}-logs-transitions"
     enabled = true
 
     transition {
-      days          = "${var.logs_transition_ia}"
+      days          = var.logs_transition_ia
       storage_class = "STANDARD_IA"
     }
 
     transition {
-      days          = "${var.logs_transition_glacier}"
+      days          = var.logs_transition_glacier
       storage_class = "GLACIER"
     }
 
     expiration {
-      days = "${var.logs_expiration}"
+      days = var.logs_expiration
     }
   }
 
-  tags = "${merge(var.tags, map("Name", format("s3-cloudfront-%s-logs", var.name)))}"
+  tags = merge(var.tags, map("Name", format("s3-cloudfront-%s-logs", var.name)))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -60,5 +60,5 @@ variable "tags" {
 
 variable "force_destroy" {
   description = "A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable."
-  default     = "false"
+  default     = false
 }


### PR DESCRIPTION
This changes the syntax of the entire project to be compatible with
Terraform 0.12.

There are some fixes that just clear out deprecation warnings, and 1 fix
that actually fixes an error that occurs because Terraform 0.12 kind of
changed how `compact` and interpolation works when doing

```
aliases = ["${compact(...)}"]
```

vs

```
aliases = compact(...)
```

This is the `aws_cloudfront_distribution.website`'s `aliases` variable
specifically.